### PR TITLE
Do not require @hapi/sntp anymore

### DIFF
--- a/API.md
+++ b/API.md
@@ -158,13 +158,19 @@ Request(requestOptions, function (error, response, body) {
 });
 ```
 
-**Hawk** utilized the [**SNTP**](https://github.com/hueniverse/sntp) module for time sync management. By default, the local
-machine time is used. To automatically retrieve and synchronize the clock within the application, use the SNTP 'start()' method.
+## Time Sync
+
+**Hawk** can utilize the [`@hapi/sntp`](https://github.com/outmoded/sntp) module for time sync management.
+By default, the local machine time is used.
+To automatically retrieve and synchronize the clock within the application, add `@hapi/sntp` to your application and initialize it at the top level:
 
 ```js
-Hawk.sntp.start();
-```
+const Sntp = require('@hapi/sntp');
+const Hawk = require('hawk');
 
+Sntp.start();
+Hawk.utils.setTimeFunction(Sntp.now)
+```
 
 ## Protocol Example
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,6 @@
 'use strict';
 
 
-exports.sntp = require('@hapi/sntp');
-
 exports.server = require('./server');
 
 exports.client = require('./client');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Boom = require('@hapi/boom');
-const Sntp = require('@hapi/sntp');
 
 
 const internals = {};
@@ -93,9 +92,20 @@ exports.parseRequest = function (req, options) {
 };
 
 
+let _now = Date.now;
+
+
+// override the `now` function, e.g., to use sntp
+
+exports.setTimeFunction = function (fn) {
+
+    _now = fn;
+};
+
+
 exports.now = function (localtimeOffsetMsec) {
 
-    return Sntp.now() + (localtimeOffsetMsec || 0);
+    return _now() + (localtimeOffsetMsec || 0);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "@hapi/b64": "5.x.x",
     "@hapi/boom": "9.x.x",
     "@hapi/cryptiles": "5.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/sntp": "4.x.x"
+    "@hapi/hoek": "9.x.x"
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,7 +10,7 @@ const Package = require('../package.json');
 const internals = {};
 
 
-const { describe, it } = exports.lab = Lab.script();
+const { describe, it, after } = exports.lab = Lab.script();
 const expect = Code.expect;
 
 
@@ -116,6 +116,20 @@ describe('Utils', () => {
         it('returns the correct package version number', () => {
 
             expect(Hawk.utils.version()).to.equal(Package.version);
+        });
+    });
+
+    describe('setTimeFunction()', () => {
+
+        after(() => {
+
+            Hawk.utils.setTimeFunction(Date.now);
+        });
+
+        it('creates the value that now() will return', () => {
+
+            Hawk.utils.setTimeFunction(() => 269323200000);
+            expect(Hawk.utils.now()).to.equal(269323200000);
         });
     });
 


### PR DESCRIPTION
This removes a Node-specific dependency from the packge, allowing its
use in a browser context (via webpack or the like).

This is a breaking change for users of SNTP, but the change is
straightforward.  For those using this functionality, note that
@hapi/sntp is no longer maintained.