### PR TITLE
Validate bewit MAC before expiry

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -377,7 +377,7 @@ exports.authenticateBewit = async function (req, credentialsFunc, options) {
 
     const bewit = {
         id: bewitParts[0],
-        exp: parseInt(bewitParts[1], 10),
+        exp: bewitParts[1],
         mac: bewitParts[2],
         ext: bewitParts[3] || ''
     };
@@ -394,12 +394,6 @@ exports.authenticateBewit = async function (req, credentialsFunc, options) {
     let url = resource[1];
     if (resource[4]) {
         url = url + resource[2] + resource[4];
-    }
-
-    // Check expiration
-
-    if (bewit.exp * 1000 <= now) {
-        throw Object.assign(Utils.unauthorized('Access expired'), { bewit });
     }
 
     // Fetch Hawk credentials
@@ -441,6 +435,12 @@ exports.authenticateBewit = async function (req, credentialsFunc, options) {
 
     if (!Cryptiles.fixedTimeComparison(mac, bewit.mac)) {
         throw Object.assign(Utils.unauthorized('Bad mac'), result);
+    }
+
+    // Check expiration
+
+    if (parseInt(bewit.exp, 10) * 1000 <= now) {
+        throw Object.assign(Utils.unauthorized('Access expired'), { bewit });
     }
 
     // Successful authentication


### PR DESCRIPTION
Checking expiry before validating the MAC means that we are passing untrusted values into `parseInt`, which might have unintended consequences (also consider other languages that copy the algorithm here since this is the reference implementation). This is only done in the wrong order for bewit validation, regular header auth already checks the MAC first.

Had to update the other expiry test since it apparently didn't have a valid MAC.